### PR TITLE
Websocket proxy support

### DIFF
--- a/forward.go
+++ b/forward.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	"github.com/yhat/wsutil"
+)
+
+type Forwarder struct {
+	httpForwarder      http.Handler
+	websocketForwarder http.Handler
+}
+
+func NewForwarder(rpURL *url.URL) *Forwarder {
+	return &Forwarder{
+		httpForwarder:      httputil.NewSingleHostReverseProxy(rpURL),
+		websocketForwarder: wsutil.NewSingleHostReverseProxy(rpURL),
+	}
+}
+
+func (f *Forwarder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if wsutil.IsWebSocketRequest(req) {
+		f.websocketForwarder.ServeHTTP(w, req)
+	} else {
+		f.httpForwarder.ServeHTTP(w, req)
+	}
+}

--- a/ior.go
+++ b/ior.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"log"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -45,7 +44,7 @@ func main() {
 	d := &Daemon{}
 	d.Refresh()
 
-	log.Print(http.ListenAndServe(*listen, reloadMiddleware(d, httputil.NewSingleHostReverseProxy(rpURL))))
+	log.Print(http.ListenAndServe(*listen, reloadMiddleware(d, NewForwarder(rpURL))))
 }
 
 func reloadMiddleware(d *Daemon, next http.Handler) http.Handler {


### PR DESCRIPTION
This allows websockets to be proxied through to the underlying app being monitored. If the underlying app is reloaded (via a http request) the connected websockets will be closed (and can be re-opened by their clients if desired).

Note that traffic over the websocket connections is not monitored in any way with this change, so the trigger for the code reload of the underlying app will still need to be done via a standard http request.

This introduces a dependency on https://github.com/yhat/wsutil which provides websocket utils similar to `net/http/httputil`. Websocket connections are held open by this proxy, and if either end experiences an error, the connection is dropped. This allows the underlying app to be reloaded (dropping it's websocket connection), and in turn the proxy drops it's websocket connection to the client.