### PR TITLE
Add -race flag to build binary with race detector

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -23,6 +23,7 @@ type Daemon struct {
 	currentCloser func()
 	lastHash      []byte
 	once          singleflight.Group
+	race          bool
 }
 
 func (d *Daemon) Refresh() error {
@@ -61,6 +62,9 @@ func (d *Daemon) install() error {
 	}
 
 	cmd := exec.Command("go", "install", "-v")
+	if d.race {
+		cmd.Args = append(cmd.Args, "-race")
+	}
 	cmd.Env = append(os.Environ(), "GOBIN="+*bindir, "PORT="+*port)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/ior.go
+++ b/ior.go
@@ -17,6 +17,7 @@ var binary = flag.String("binary", "", "The binary to run after installing")
 var port = flag.String("port", "3000", "The port the app should listen on, will set PORT")
 var upstream = flag.String("upstream", "", "Where to connect to access the app")
 var listen = flag.String("listen", ":3030", "Where to listen")
+var race = flag.Bool("race", false, "Build binary with -race instrumentation")
 
 func mustCwd() string {
 	wd, err := os.Getwd()
@@ -41,7 +42,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	d := &Daemon{}
+	d := &Daemon{
+		race: *race,
+	}
 	d.Refresh()
 
 	log.Print(http.ListenAndServe(*listen, reloadMiddleware(d, NewForwarder(rpURL))))


### PR DESCRIPTION
The [Go Race Detector](https://blog.golang.org/race-detector) is great. It can be used to find races in your application when running tests/benchmarks, but can also be run under development/production loads to find races that occur outside of tested code.

This adds the option to build the resulting binary with the race detector enabled. I'd like to run my development builds with the race detector on to get extra assurance that the application is built right.